### PR TITLE
Add router_type option to CreateRouters

### DIFF
--- a/qingcloud/cli/iaas_client/actions/instance/run_instances.py
+++ b/qingcloud/cli/iaas_client/actions/instance/run_instances.py
@@ -35,6 +35,10 @@ class RunInstancesAction(BaseAction):
                 help='instance type: small_b, small_c, medium_a, medium_b, medium_c, \
                 large_a, large_b, large_c')
 
+        parser.add_argument('-i', '--instance_class', dest='instance_class',
+                action='store', type=str, default=None,
+                help='instance class: 0 is performance; 1 is high performance, default 0.')
+
         parser.add_argument('-c', '--count', dest = 'count',
                 action='store', type=int, default=1,
                 help='the number of instances to launch, default 1.')
@@ -111,6 +115,7 @@ class RunInstancesAction(BaseAction):
         return {
                 'image_id': options.image_id,
                 'instance_type' : options.instance_type,
+                'instance_class' : options.instance_class,
                 'cpu': options.cpu,
                 'memory': options.memory,
                 'instance_name' : options.instance_name,

--- a/qingcloud/cli/iaas_client/actions/router/create_routers.py
+++ b/qingcloud/cli/iaas_client/actions/router/create_routers.py
@@ -20,7 +20,7 @@ class CreateRoutersAction(BaseAction):
 
     action = 'CreateRouters'
     command = 'create-routers'
-    usage = '%(prog)s [-c <count>] [-n <router_name>] [-f <conf_file>]'
+    usage = '%(prog)s [-c <count>] [-N <router_name>] [-f <conf_file>]'
 
     @classmethod
     def add_ext_arguments(cls, parser):
@@ -40,6 +40,10 @@ class CreateRoutersAction(BaseAction):
                 action='store', type=str, default=None,
                 help='VPC IP addresses range, currently support "192.168.0.0/16" or "172.16.0.0/16", required in zone pek3a')
 
+        parser.add_argument('-t', '--router_type', dest='router_type',
+                action='store', type=str, default=None,
+                help='0 - Medium, 1 - Small, 2 - large, 3 - extra-large (default is 1)')
+
     @classmethod
     def build_directive(cls, options):
         required_params = {
@@ -55,4 +59,5 @@ class CreateRoutersAction(BaseAction):
                 'router_name' : options.router_name,
                 'security_group': options.security_group,
                 'vpc_network': options.vpc_network,
+                'router_type': options.router_type
                 }


### PR DESCRIPTION
Please see the the pull request 29 for the qingcloud-sdk-python: https://github.com/yunify/qingcloud-sdk-python/pull/29

This implements the router_type option in the CLI for create-routers command