### PR TITLE
compatible with Python 3

### DIFF
--- a/qingcloud/cli/qs_client/actions/key.py
+++ b/qingcloud/cli/qs_client/actions/key.py
@@ -154,7 +154,7 @@ class GetObjectAction(BaseAction):
         resp = cls.conn.make_request("GET", options.bucket, options.key, headers=headers)
 
         if resp.status in (HTTP_OK, HTTP_OK_PARTIAL_CONTENT):
-            with open(path, "w") as f:
+            with open(path, "wb") as f:
                 while True:
                     buf = resp.read(BUFSIZE)
                     if not buf:


### PR DESCRIPTION
`pip install qingcloud-cli` 安装 `qingcloud-cli` 

Python 3 下运行 `qingcloud qs get-object -b <bucket-name> -k <key> `，报错如下：

```
Traceback (most recent call last):

  File "$HOME/.pyenv/versions/3.7.1/envs/py37/bin/qingcloud", line 25, in <module>
    sys.exit(main())
    │   │    └ <function main at 0x105dc4598>
    │   └ <built-in function exit>
    └ <module 'sys' (built-in)>

  File "$HOME/.pyenv/versions/3.7.1/envs/py37/bin/qingcloud", line 22, in main
    return qingcloud.cli.driver.main()
           │         │   │      └ <function main at 0x106f988c8>
           │         │   └ <module 'qingcloud.cli.driver' from '$HOME/.pyenv/versions/3.7.1/envs/py37/lib/python3.7/site-packages/qingcloud/cli/driver....
           │         └ <module 'qingcloud.cli' from '$HOME/.pyenv/versions/3.7.1/envs/py37/lib/python3.7/site-packages/qingcloud/cli/__init__.py'>
           └ <module 'qingcloud' from '$HOME/.pyenv/versions/3.7.1/envs/py37/src/qingcloud-sdk/qingcloud/__init__.py'>

  File "$HOME/.pyenv/versions/3.7.1/envs/py37/lib/python3.7/site-packages/qingcloud/cli/driver.py", line 102, in main
    action.main(args[3:])
    │      │    └ ['$HOME/.pyenv/versions/3.7.1/envs/py37/bin/qingcloud', 'qs', 'get-object', '-b', 'bucket-name', '-k', 'cal']
    │      └ <bound method BaseAction.main of <class 'qingcloud.cli.qs_client.actions.key.GetObjectAction'>>
    └ <class 'qingcloud.cli.qs_client.actions.key.GetObjectAction'>
  File "$HOME/.pyenv/versions/3.7.1/envs/py37/lib/python3.7/site-packages/qingcloud/cli/qs_client/actions/base.py", line 90, in main
    return cls.send_request(options)
           │   │            └ Namespace(bucket='bucket-name', bytes=None, conf_file='~/.qingcloud/config.yaml', file=None, key='cal')
           │   └ <bound method GetObjectAction.send_request of <class 'qingcloud.cli.qs_client.actions.key.GetObjectAction'>>
           └ <class 'qingcloud.cli.qs_client.actions.key.GetObjectAction'>
  File "$HOME/.pyenv/versions/3.7.1/envs/py37/lib/python3.7/site-packages/qingcloud/cli/qs_client/actions/key.py", line 162, in send_request
    f.write(buf)
    │ │     └ b'     April 2019       \nSu Mo Tu We Th Fr Sa  \n    1  2  3  4  5  6  \n 7  8  9 10 11 12 13  \n14 15 16 17 18 19 20  \n21 22 ...
    │ └ <built-in method write of _io.TextIOWrapper object at 0x106f617e0>
    └ <_io.TextIOWrapper name='/tmp/cal' mode='w' encoding='UTF-8'>

TypeError: write() argument must be str, not bytes

```